### PR TITLE
JIRA NEX-651 Don't treat radio call signs with trailing spaces as an error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ buildNumber.properties
 .classpath
 .project
 .settings
+/.idea/

--- a/src/main/java/au/gov/amsa/fgb/internal/Conversions.java
+++ b/src/main/java/au/gov/amsa/fgb/internal/Conversions.java
@@ -558,7 +558,7 @@ final class Conversions {
                             mbaudotStr = mbaudotStr + "?";
                             e.add(mbaudotSubBits + " = Space - Non-Spec\n");
                         } else {
-                            mbaudotStr = mbaudotStr + "*";
+                            mbaudotStr = mbaudotStr + " ";
                             e.add(mbaudotSubBits + " = Space - Right Justified\n");
                         }
                     } else {
@@ -586,6 +586,8 @@ final class Conversions {
             }
 
         } // end of for loop
+
+        mbaudotStr = mbaudotStr.replaceAll("\\s+$", "");
 
         // Deal with SPACE if the protocol is not User Radio Call Sign, these protocols
         // are: UserAviation, UserMaritime and UserSerialAircraftOperator

--- a/src/test/java/au/gov/amsa/fgb/internal/DecoderTest.java
+++ b/src/test/java/au/gov/amsa/fgb/internal/DecoderTest.java
@@ -30,7 +30,7 @@ public class DecoderTest {
     // private static final String HEXSTRING_15_CHRS = "ADCC40504000185";
     // private static final String HEXSTRING_15_CHRS_AVIATION = "BEE64BE562F9BD9";
     private static final String HEXSTRING_30_CHRS = "D6E6202820000C29FF51041775302D";
-    private static final boolean COMPARE_WITH_LEGACY = true;
+    private static final boolean COMPARE_WITH_LEGACY = false;
 
     @Test
     public void testDecodeToJsonWith30Chr() {
@@ -92,7 +92,6 @@ public class DecoderTest {
                     String hex = file.getName().substring(0, file.getName().indexOf("."));
                     String expected = readString(file);
                     String json = Decoder.decodeFullAsJson(hex);
-                    System.out.println(file);
                     if (REWRITE_COMPLIANCE_KIT) {
                         Files.write(file.toPath(), json.getBytes(StandardCharsets.UTF_8));
                     } else {
@@ -101,6 +100,7 @@ public class DecoderTest {
                     if (COMPARE_WITH_LEGACY) {
                         File f = new File("src/test/resources/legacy-output", file.getName());
                         if (f.exists()) {
+                            System.out.println(file);
                             String legacy = readString(f);
                             System.out.println("================================");
                             System.out.println(json);

--- a/src/test/java/au/gov/amsa/fgb/internal/HexDecoderTest.java
+++ b/src/test/java/au/gov/amsa/fgb/internal/HexDecoderTest.java
@@ -99,6 +99,13 @@ public final class HexDecoderTest {
     }
 
     @Test
+    public void testDecodeWithRadioCallsignWithTrailingSpaces() {
+        String hex = "C1AAD9FEF6490D1";
+        Map<String, HexAttribute> m = decodeToMap(hex);
+        assertEquals("PMKQ", m.get("radioCallsign").value());
+    }
+
+    @Test
     public void testDecode() {
         String hex = "D6E67C5F61F89568772240FFFFFFFF";
         Decoder.decodeFullAsJson(hex);


### PR DESCRIPTION
Trailing spaces in radio call signs are not an error. Trim trailing spaces in all attributes decoded from hex codes.